### PR TITLE
docs: add AGENTS.md for AI agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# 🤖 Agent Instructions for @idangoldman/plate
+
+**Welcome!** This document outlines the mandatory rules, style guidelines, and technical setup for AI agents working in this repository.
+
+**Adherence to this file is mandatory** for all codebase modifications.
+
+## 🏗️ Architecture & Code Style
+
+*   **TypeScript Only:** This project is entirely written in TypeScript (migrated from CoffeeScript). **Do not use or introduce CoffeeScript.**
+*   **Module System:** The project compiles to **CommonJS**.
+*   **Imports:** We use standard extensionless imports and utilize `~/` for absolute path aliases.
+*   **Design Pattern:**
+    *   The project extends native prototypes (`Array`, `Object`, `String`).
+    *   **Keep pure functions strictly separate from mutation logic.**
+    *   Global typings are used alongside an `applyAll()` hook.
+
+## 🧪 Testing Guidelines
+
+*   **BDD with Cucumber:** Tests are written in Behavior-Driven Development (BDD) style using **Cucumber**.
+*   **Test Location:** All tests are located in `.feature` files within the `tests/features` directory.
+*   **Execution Runtime:** Tests run TypeScript using `tsx`.
+    *   *Configuration:* Located at `configs/cucumber.yml`.
+    *   *Under the hood command:* `NODE_OPTIONS="--import tsx" cucumber-js`
+
+## 🛠️ Build & Package Management
+
+*   **Package Manager:** We use **pnpm**.
+    *   *Requirement:* Node.js >= v22.13.0 (specified in `.node-version`).
+*   **Build Tools:** The library is built using `tsc && tsc-alias`.
+*   **Task Runner:** We use `go-task` (Taskfile). Configurations are located in the `tasks/` directory (e.g., `Taskfile.build.yml`, `Taskfile.tests.yml`).
+
+## 🛑 Mandatory Pre-Commit Checks
+
+Before you finalize your work or conclude any task, **you MUST successfully run the following commands and ensure they pass:**
+
+1.  **Run Tests:** Check for regressions or test failures.
+    ```bash
+    task tests:run
+    ```
+2.  **Run Build:** Ensure the project compiles successfully.
+    ```bash
+    task build:run
+    ```
+
+**If any of these commands fail, you must fix the issues before proceeding.**


### PR DESCRIPTION
Added `AGENTS.md` file to the root of the repository. This document outlines the mandatory rules, code style guidelines, and technical setup for AI agents working in this repository based on memory details and user instructions. It provides an "ADHD-friendly" format with clear headings, bullet points, and bold text, and explicitly mandates running `task tests:run` and `task build:run` as pre-commit checks.

---
*PR created automatically by Jules for task [15569830083403303868](https://jules.google.com/task/15569830083403303868) started by @idangoldman*