### PR TITLE
chore(release): add github actions for version bump and changelog

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,56 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+
+      - name: Get current version
+        id: get_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          if git ls-remote --tags origin refs/tags/v${{ steps.get_version.outputs.version }} | grep -q 'refs/tags/'; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create v${{ steps.get_version.outputs.version }} \
+            --title "Release v${{ steps.get_version.outputs.version }}" \
+            --generate-notes \
+            --target main
+
+  publish:
+    needs: create-release
+    # Note: If the create-release job creates the release via GH action (using GITHUB_TOKEN),
+    # the normal "release: [published]" trigger might NOT fire due to GitHub's recursive action prevention.
+    # Therefore, we call the publish workflow directly.
+    uses: ./.github/workflows/npm-publish.yml
+    secrets: inherit

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,7 @@
 name: Publish Package to NPM
 on:
   workflow_dispatch:
+  workflow_call:
 
   release:
     types: [published]

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,43 @@
+name: Prepare Release
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  prepare-release:
+    if: github.event.label.name == 'prepare-release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+
+      - name: Bump minor version
+        run: |
+          npm version minor --no-git-tag-version
+
+      - name: Generate Changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: --unreleased --tag $(node -p "require('./package.json').version") --prepend CHANGELOG.md
+
+      - name: Commit files
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(release): bump version and update changelog [skip ci]"
+          file_pattern: "package.json CHANGELOG.md"
+          branch: ${{ github.head_ref }}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,9 @@ See [CHANGELOG.md](CHANGELOG.md) file for what is already done and available for
 
 ## Next Release (0.11.0)
 
-- [ ] 3/4 patterns code refactor, moving from the current native prototypes extension only to function -> class -> index -> apply
-- [ ] Tests code adjustments for 3/4 patterns
-- [ ] Test coverage for prototypes pattern and extension of native js prototypes
+- [x] 3/4 patterns code refactor, moving from the current native prototypes extension only to function -> class -> index -> apply
+- [x] Tests code adjustments for 3/4 patterns
+- [x] Test coverage for prototypes pattern and extension of native js prototypes
 - [ ] (?) JSDoc style documentation coverage of 3/4 patterns
 - [ ] Generated or handwritten typescript interfaces and types based on JSDoc documentation
 - [ ] Update package json exports paths, via a cli command?


### PR DESCRIPTION
This PR fulfills the requested release workflows:
1. Marks completed TypeScript migration tasks in `ROADMAP.md`.
2. Adds a new `prepare-release.yml` GitHub action. When a PR is labeled with `prepare-release`, it performs a minor version bump (`npm version minor`) and generates changelog entries using `git-cliff-action`, and pushes these changes to the PR branch.
3. Adds a new `create-release.yml` GitHub action. It triggers on merges/pushes to `main`, reads the current package version, and automatically creates a new Git Tag and GitHub Release. 
4. Updates the existing `npm-publish.yml` to support `workflow_call`, enabling the `create-release` action to trigger publishing to npm automatically without relying on `[published]` event type recursively from the bot.

---
*PR created automatically by Jules for task [10070933704818916458](https://jules.google.com/task/10070933704818916458) started by @idangoldman*